### PR TITLE
WatermelonToken.sol: fix decimals

### DIFF
--- a/hardhat/erc20/contracts/WatermelonToken.sol
+++ b/hardhat/erc20/contracts/WatermelonToken.sol
@@ -7,4 +7,8 @@ contract WatermelonToken is ERC20 {
     constructor(uint256 initialSupply) ERC20("Watermelon", "WTM") {
         _mint(msg.sender, initialSupply);
     }
+
+    function decimals() public pure override(ERC20) returns (uint8) {
+        return 0;
+    }
 }


### PR DESCRIPTION
Set decimal places for example https://doc.aurora.dev/develop/start/hardhat
By default, there are 18 decimal places. Here quote from the documentation

> The ERC-20 example is about a naive Watermelon token 🍉. You can exchange them into actual Watermelons 🍉🍉🍉. The total supply is 1000000, the minter is the contract deployer address, and the decimals are 0 (One token → One watermelon).

